### PR TITLE
Implement query to get the most popular genre by year

### DIFF
--- a/controllers/movieGenreController.js
+++ b/controllers/movieGenreController.js
@@ -1,9 +1,9 @@
 const queries = require("../lib/db/queries/index");
 
 const getMovieGenre = async (req, res) => {
-  let movies = await queries.getMovies();
-  console.log('movies: ', movies);
-  res.status(200).send('getMovieGenre');
+  const data = await queries.getMostPopularGenre(req.query.year);
+  console.log('genre data: ', data);
+  res.status(200).json(data);
 }
 
 exports.getMovieGenre = getMovieGenre;

--- a/controllers/productionCompanyController.js
+++ b/controllers/productionCompanyController.js
@@ -1,5 +1,5 @@
 const getProductionCompanyFinancials = async (req, res) => {
-  res.status(200).send('getProductionCompanyFinancials');
+  res.status(200).send(`production company: ${req.query['production-company']}, year: ${req.query.year}`);
 }
 
 exports.getProductionCompanyFinancials = getProductionCompanyFinancials;

--- a/lib/db/queries/getMostPopularGenre.js
+++ b/lib/db/queries/getMostPopularGenre.js
@@ -1,0 +1,32 @@
+const { dbQuery } = require("../conn");
+
+async function getMostPopularGenre(releaseYear) {
+  const query = `
+    WITH genre_revenue_by_year AS (
+      SELECT
+        mg.name AS genre,
+        extract(year from release_date) AS release_year,
+        SUM(m.revenue) AS revenue
+      FROM movies m
+        JOIN movies_genres mg ON mg.movie_id = m.id
+      GROUP BY 1, 2
+    ), top_revenue_genre_by_year AS (
+      SELECT 
+        genre,
+        release_year,
+        RANK() OVER (PARTITION BY release_year ORDER BY revenue DESC) AS rank
+      FROM genre_revenue_by_year
+      ${ releaseYear ? 'WHERE release_year = ' + releaseYear : ''}
+    )
+    SELECT 
+      release_year,
+      genre
+    FROM top_revenue_genre_by_year
+    WHERE rank = 1
+    ORDER BY 1 DESC;
+  `
+  let result = await dbQuery(query);
+  return result.rows
+}
+
+module.exports = getMostPopularGenre;

--- a/lib/db/queries/index.js
+++ b/lib/db/queries/index.js
@@ -2,10 +2,12 @@ const getMovies = require("./getMovies");
 const insertMovie = require("./insertMovie");
 const insertMovieGenre = require("./insertMovieGenre");
 const insertMovieProductionCompany = require("./insertMovieProductionCompany");
+const getMostPopularGenre = require("./getMostPopularGenre")
 
 module.exports = {
   getMovies,
   insertMovie,
   insertMovieGenre,
-  insertMovieProductionCompany
+  insertMovieProductionCompany,
+  getMostPopularGenre
 }

--- a/routes/api.js
+++ b/routes/api.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const productionCompanyController = require('../controllers/productionCompanyController');
 const movieGenreController = require('../controllers/movieGenreController');
 
-router.get('/production_companies/financials', productionCompanyController.getProductionCompanyFinancials);
+router.get('/production-companies/financials', productionCompanyController.getProductionCompanyFinancials);
 router.get('/genres', movieGenreController.getMovieGenre);
 
 module.exports = router;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE movies (
   id serial PRIMARY KEY,
   title text NOT NULL UNIQUE,
-  release_date text,
+  release_date TIMESTAMP,
   budget INT,
   revenue INT,
   vote_average INT,


### PR DESCRIPTION
This PR: 
* Adds the query to get the most popular genre by year (or for a single year if an arg is provided) 
* Adds a call to the query from the `movieGenreController`

Validation (requests with limited data seeded in DB): 

**Request** 
* GET http://localhost:3001/api/genres?year=1995

**Response**
```json
[
    {
        "release_year": "1995",
        "genre": "Drama"
    }
]
```

**Request**
* GET http://localhost:3001/api/genres

**Response**
```json
[
    {
        "release_year": "1996",
        "genre": "Comedy"
    },
    {
        "release_year": "1995",
        "genre": "Drama"
    },
    {
        "release_year": "1994",
        "genre": "Documentary"
    },
    {
        "release_year": "1993",
        "genre": "Comedy"
    },
    {
        "release_year": "1993",
        "genre": "Drama"
    },
    {
        "release_year": "1992",
        "genre": "Romance"
    },
    {
        "release_year": "1992",
        "genre": "Comedy"
    },
    {
        "release_year": "1976",
        "genre": "Crime"
    },
    {
        "release_year": "1976",
        "genre": "Drama"
    },
    {
        "release_year": "1967",
        "genre": "Drama"
    },
    {
        "release_year": "1967",
        "genre": "Romance"
    },
    {
        "release_year": "1964",
        "genre": "Drama"
    },
    {
        "release_year": "1964",
        "genre": "Romance"
    }
]
```
